### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,7 @@ ENCODE = brotli/enc/backward_references.cc brotli/enc/histogram.cc	\
  brotli/enc/brotli_bit_stream.cc brotli/enc/metablock.cc		\
  brotli/enc/encode.cc brotli/enc/static_dict.cc				\
  brotli/enc/encode_parallel.cc brotli/enc/streams.cc			\
- brotli/enc/entropy_encode.cc brotli/enc/dictionary.cc and		\
- brotli/enc/utf8_util.cc.
+ brotli/enc/entropy_encode.cc brotli/enc/utf8_util.cc                   
 
 DECODEHEADERS = brotli/dec/decode.h brotli/dec/state.h			\
  brotli/dec/streams.h brotli/dec/types.h brotli/dec/bit_reader.h	\


### PR DESCRIPTION
And I also get a build error: Can you try building HEAD? I can't get it to work.

```
make
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
  CC       brotli/dec/libbrotlidec_la-bit_reader.lo
  CC       brotli/dec/libbrotlidec_la-decode.lo
  CC       brotli/dec/libbrotlidec_la-huffman.lo
  CC       brotli/dec/libbrotlidec_la-state.lo
  CC       brotli/dec/libbrotlidec_la-streams.lo
  CC       brotli/dec/libbrotlidec_la-dictionary.lo
  CCLD     libbrotlidec.la
  CXX      brotli/enc/libbrotlienc_la-backward_references.lo
  CXX      brotli/enc/libbrotlienc_la-histogram.lo
  CXX      brotli/enc/libbrotlienc_la-block_splitter.lo
  CXX      brotli/enc/libbrotlienc_la-literal_cost.lo
  CXX      brotli/enc/libbrotlienc_la-brotli_bit_stream.lo
  CXX      brotli/enc/libbrotlienc_la-metablock.lo
  CXX      brotli/enc/libbrotlienc_la-encode.lo
  CXX      brotli/enc/libbrotlienc_la-static_dict.lo
  CXX      brotli/enc/libbrotlienc_la-encode_parallel.lo
  CXX      brotli/enc/libbrotlienc_la-streams.lo
  CXX      brotli/enc/libbrotlienc_la-entropy_encode.lo
make[1]: *** No rule to make target `brotli/enc/dictionary.cc', needed by `brotli/enc/libbrotlienc_la-dictionary.lo'.  Stop.
make: *** [all] Error 2
```
