### PR TITLE
Be explicit about dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ and encode sources. Uses autotools.
 
 # Build
 
+First make sure you have `libtool`, `autoconf` and `automake` installed.
+
 Clone the libbrotli repository, e.g.
 
 	$ git clone https://github.com/bagder/libbrotli


### PR DESCRIPTION
The errors generated when these prerequisites aren't installed can be a bit opaque so this patch adds a line to README.md listing them out.
