### PR TITLE
update README to reflect brotle is licensed MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ in your source code.
 
 # License
 
-Consider these build files MIT licensed. brotli itself has its own [Apache v2
-license](https://github.com/google/brotli/blob/master/LICENSE).
-
-[The Apache v2 license is not considered compatible with GPLv2](http://www.apache.org/licenses/GPL-compatibility.html)
+Consider these build files MIT licensed. brotli itself is also under an
+[MIT license](https://github.com/google/brotli/blob/master/LICENSE).
 
 # Server-side brotli
 


### PR DESCRIPTION
this change happened in google/brotli@771eb10
