### PR TITLE
Makefile: Add missing encoding header.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,8 @@ ENCODEHEADERS = brotli/enc/encode.h brotli/enc/command.h		\
  brotli/enc/entropy_encode.h brotli/enc/brotli_bit_stream.h             \
  brotli/enc/write_bits.h brotli/enc/static_dict_lut.h                   \
  brotli/enc/encode_parallel.h brotli/enc/types.h brotli/enc/utf8_util.h \
- brotli/enc/compress_fragment.h brotli/enc/compress_fragment_two_pass.h
+ brotli/enc/compress_fragment.h brotli/enc/compress_fragment_two_pass.h \
+ brotli/enc/entropy_encode_static.h
 
 EXTRA_DIST = AUTHORS README
 


### PR DESCRIPTION
I found another missing encoding header in Makefile.am.

I actually got annoyed enough, that this happend to me again, to come up with [some Python](https://gist.github.com/mundry/2f2d4ed6cb29b510708a) to help me 
find inconsistencies. Maybe someone else with find use in that, too.
