### PR TITLE
Makefile: Add libm linker option for libbrotlienc.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,7 +91,7 @@ libbrotlidec_la_CPPFLAGS = $(AM_CPPFLAGS) $(libbrotli_la_CPPFLAGS_EXTRA)
 libbrotlidec_la_SOURCES = $(DECODE) $(DECODEHEADERS) $(COMMON) #$(COMMONHEADERS)
 
 libbrotlienc_la_CPPFLAGS_EXTRA = -DBROTLI_BUILDING_LIBRARY
-libbrotlienc_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLIENC_VERSION_INFO) $(LDFLAGS)
+libbrotlienc_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLIENC_VERSION_INFO) $(LDFLAGS) -lm
 libbrotlienc_la_CFLAGS = $(AM_CFLAGS) $(libbrotli_la_CFLAGS_EXTRA)
 libbrotlienc_la_CXXFLAGS =
 libbrotlienc_la_CPPFLAGS = $(AM_CPPFLAGS) $(libbrotli_la_CPPFLAGS_EXTRA)


### PR DESCRIPTION
libbrotlienc links against libm now.

I'm not too familiar with autotools, does this require another configure check for libm?
