### PR TITLE
Replace type with command -v to check for availability

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,12 +1,12 @@
 # !/bin/sh -e
 
-AUTORECONF=`which autoreconf 2>/dev/null`
+AUTORECONF=`command -v autoreconf 2>/dev/null`
 if test $? -ne 0; then
   echo "No 'autoreconf' found. You must install the autoconf package."
   exit 1
 fi
 
-GIT=`which git 2>/dev/null`
+GIT=`command -v git 2>/dev/null`
 if test $? -ne 0; then
   echo "No 'git' found. You must install the git package."
   exit 1


### PR DESCRIPTION
Hi @bagder 

Today I tried to install libbrotli on a minimal Centos 7 installation but the autogen.sh failed each time with the message ` No 'autoreconf' found. You must install the autoconf package.` 
I had the autoconf package installed so I looked into the shell script and found the problem. On a minimal Centos installation the `which`command is not available so hereby my alternative `command -v` which should work across all platforms and is less resource heavy:

> Avoid which. Not only is it an external process you're launching for doing very little (meaning builtins like hash, type or command are way cheaper), you can also rely on the builtins to actually do what you want, while the effects of external commands can easily vary from system to system.

http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script