### PR TITLE
build the brotli command line tool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,8 @@ AUTOMAKE_OPTIONS = foreign nostdinc subdir-objects
 
 ACLOCAL_AMFLAGS = -I m4
 
+SUBDIRS = . tools
+
 lib_LTLIBRARIES = libbrotlidec.la libbrotlienc.la
 
 DECODE = brotli/c/dec/bit_reader.c brotli/c/dec/decode.c  \
@@ -24,7 +26,6 @@ DECODEHEADERS = brotli/c/include/brotli/decode.h brotli/c/dec/state.h  \
  brotli/c/dec/context.h brotli/c/dec/prefix.h                          \
  brotli/c/common/constants.h brotli/c/common/dictionary.h              \
  brotli/c/common/version.h brotli/c/dec/transform.h brotli/c/dec/port.h
-
 
 ENCODEHEADERS = brotli/c/include/brotli/encode.h brotli/c/enc/command.h     \
  brotli/c/enc/hash.h brotli/c/enc/ringbuffer.h brotli/c/enc/static_dict.h   \

--- a/configure.ac
+++ b/configure.ac
@@ -7,9 +7,12 @@ AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
 AM_INIT_AUTOMAKE()
 AM_MAINTAINER_MODE
+AM_INIT_AUTOMAKE([subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_PROG_CC
 
-AC_CONFIG_FILES([Makefile libbrotlienc.pc libbrotlidec.pc])
+dnl AC_PATH_PROG(BROTLI	, brotli, /usr/bin/brotli)
+
+AC_CONFIG_FILES([Makefile libbrotlienc.pc libbrotlidec.pc tools/Makefile])
 AC_OUTPUT

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,0 +1,4 @@
+bin_PROGRAMS = brotli
+
+brotli_SOURCES = ../brotli/c/tools/brotli.c
+brotli_LDADD = $(top_builddir)/libbrotlienc.la $(top_builddir)/libbrotlidec.la  -lm


### PR DESCRIPTION
When everything is configured to build the libraries, it's convenient to build and install the brotli command line tool at the same time.