### PR TITLE
fix Brotli tool build error "brotli-brotli.Po: No such file or directory"

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = brotli
 
 brotli_CPPFLAGS = -I$(top_srcdir)/brotli/c/include
-brotli_SOURCES = $(top_srcdir)/brotli/c/tools/brotli.c
+brotli_SOURCES = brotli.c
 brotli_LDADD = $(top_builddir)/libbrotlienc.la $(top_builddir)/libbrotlidec.la  -lm

--- a/tools/brotli.c
+++ b/tools/brotli.c
@@ -1,0 +1,1 @@
+../brotli/c/tools/brotli.c


### PR DESCRIPTION
Use a symlink to the brotli tool source file to work around automake dependency file generation error.