### PR TITLE
Makefile: Install select man pages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc subdir-objects
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = . tools
+SUBDIRS = . docs tools
 
 lib_LTLIBRARIES = libbrotlidec.la libbrotlienc.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,5 +14,5 @@ AC_PROG_CC
 
 dnl AC_PATH_PROG(BROTLI	, brotli, /usr/bin/brotli)
 
-AC_CONFIG_FILES([Makefile libbrotlienc.pc libbrotlidec.pc tools/Makefile])
+AC_CONFIG_FILES([Makefile libbrotlienc.pc libbrotlidec.pc tools/Makefile docs/Makefile])
 AC_OUTPUT

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,0 +1,5 @@
+man_MANS = ../brotli/docs/brotli.1
+
+install-data-hook:
+	ln -sf brotli.1 \
+		$(DESTDIR)$(man1dir)/unbrotli.1

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -3,3 +3,7 @@ bin_PROGRAMS = brotli
 brotli_CPPFLAGS = -I$(top_srcdir)/brotli/c/include
 brotli_SOURCES = brotli.c
 brotli_LDADD = $(top_builddir)/libbrotlienc.la $(top_builddir)/libbrotlidec.la  -lm
+
+install-exec-hook:
+	ln -sf brotli \
+		$(DESTDIR)$(bindir)/unbrotli$(EXEEXT)


### PR DESCRIPTION
Installs `brotli.1` and `unbrotli.1` in the appropriate man dir.

Basing this off of #48 since it doesn't make sense to install `unbrotli.1` without it being a valid executable.